### PR TITLE
16kb page size support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 .gradle
 .DS_Store
 *.patch
-*.so
 *.dll
 *.dylib
 hs_err*.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,8 @@ set(LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/lib)
 # set the include directories
 include_directories(${include_dirs})
 
+target_link_options(${CMAKE_PROJECT_NAME} PRIVATE "-Wl,-z,max-page-size=16384")
+
 # link the necessary libraries
 target_link_libraries(j2v8
     v8_monolith

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'maven'
 apply plugin: 'signing'
 
 group = 'com.eclipsesource.j2v8'
@@ -17,10 +16,11 @@ configurations {
 
 buildscript {
     repositories {
-        jcenter()
+        google()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:8.12.0'
         classpath 'com.stanfy.spoon:spoon-gradle-plugin:1.2.2'
     }
 }
@@ -28,25 +28,26 @@ buildscript {
 apply plugin: 'com.android.library'
 apply plugin: 'spoon'
 
-repositories {
-    jcenter()
+repositories {    
+    google()
+    mavenCentral()
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
     //testCompile 'org.mockito:mockito-all:2.6.3'
-    testCompile 'org.mockito:mockito-core:2.6.3'
+    testImplementation 'org.mockito:mockito-core:2.6.3'
 
-    androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'org.mockito:mockito-android:2.6.3' // https://jeroenmols.com/blog/2017/01/17/mockitoandroid/
-    androidTestCompile 'com.android.support:support-annotations:24.0.0'
-    androidTestCompile 'com.android.support.test:runner:0.5'
-    androidTestCompile 'com.android.support.test:rules:0.5'
+    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation 'org.mockito:mockito-android:2.6.3' // https://jeroenmols.com/blog/2017/01/17/mockitoandroid/
+    androidTestImplementation 'com.android.support:support-annotations:24.0.0'
+    androidTestImplementation 'com.android.support.test:runner:0.5'
+    androidTestImplementation 'com.android.support.test:rules:0.5'
 }
 
 android {
-    compileSdkVersion 10
-    buildToolsVersion '24.0.3'
+    compileSdk 35
+    namespace "com.eclipsesource.v8"
 
     defaultConfig {
         minSdkVersion 10
@@ -89,49 +90,3 @@ signing {
     // required { has("release") && gradle.taskGraph.hasTask("uploadArchives") }
     sign configurations.archives
 }
-
-uploadArchives {
-  repositories {
-    mavenDeployer {
-      beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-
-      repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-        authentication(userName: System.getenv("MAVEN_REPO_USER"), password: System.getenv("MAVEN_REPO_PASS") )
-      }
-
-      snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-        authentication(userName: System.getenv("MAVEN_REPO_USER"), password: System.getenv("MAVEN_REPO_PASS") )
-      }
-
-      pom.project {
-	    name 'j2v8'
-	    packaging 'aar'
-	    description 'J2V8 is a set of Java bindings for V8'
-	    url 'https://github.com/eclipsesource/j2v8'
-
-	    scm {
-		url 'scm:git:git@github.com:eclipsesource/J2V8.git'
-		connection 'scm:git:git@github.com:eclipsesource/J2V8.git'
-		developerConnection 'scm:git:git@github.com:eclipsesource/J2V8.git'
-	    }
-
-	    licenses {
-		license {
-		    name 'Eclipse Public License - v 1.0'
-		    url 'https://www.eclipse.org/legal/epl-v10.html'
-		    distribution 'repo'
-		}
-	    }
-
-	    developers {
-		developer {
-		    id 'irbull'
-		    name 'R. Ian Bull'
-		    email 'irbull@eclipsesource.com'
-		}
-	    }
-
-        }
-      }
-    }
-  }

--- a/docker/android/Dockerfile
+++ b/docker/android/Dockerfile
@@ -2,6 +2,10 @@ ARG sys_image=ubuntu:20.04
 
 FROM $sys_image
 
+ARG MIRROR=ftp.uni-stuttgart.de/ubuntu
+RUN sed -i "s|archive.ubuntu.com|${MIRROR}|g" /etc/apt/sources.list && \
+    sed -i "s|security.ubuntu.com|${MIRROR}|g" /etc/apt/sources.list
+
 RUN mkdir -p /temp/docker/shared/
 WORKDIR /temp/docker/shared/
 
@@ -15,7 +19,7 @@ RUN ./install.debian.packages.sh
 
 ENV ANDROID_HOME "/usr/local/android-sdk"
 
-ENV NDK_VERSION "r26b"
+ENV NDK_VERSION "r28c"
 ENV NDK_NAME "android-ndk-$NDK_VERSION-linux"
 RUN echo "Preparing Android NDK..." && \
     mkdir -p /build && \
@@ -33,22 +37,21 @@ ENV PATH "$PATH:/build/android-gcc-toolchain:$NDK"
 
 ENV PATH "$PATH:$ANDROID_HOME/tools"
 ENV PATH "$PATH:$ANDROID_HOME/platform-tools"
+ENV PATH "$PATH:$ANDROID_HOME/tools/bin"
+ENV PATH "$PATH:$ANDROID_HOME/cmdline-tools/bin"
+
 
 RUN mkdir -p ${ANDROID_HOME} && \
     cd ${ANDROID_HOME} && \
-    wget -q https://dl.google.com/android/repository/sdk-tools-linux-3859397.zip -O android_tools.zip && \
+    wget -q https://dl.google.com/android/repository/commandlinetools-linux-13114758_latest.zip -O android_tools.zip && \
     unzip -qq android_tools.zip && \
     rm android_tools.zip
 
-RUN mkdir /usr/local/android-sdk/tools/keymaps && \
-    touch /usr/local/android-sdk/tools/keymaps/en-us
 
 COPY ./shared/install.jdk.sh /temp/docker/shared
 RUN ./install.jdk.sh
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64/
 RUN export JAVA_HOME
-
-ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
 
 COPY ./shared/install-android-dependencies.sh /temp/docker/shared
 RUN ./install-android-dependencies.sh
@@ -68,7 +71,7 @@ RUN apt-get update \
 
 COPY ./shared/install.gradle.sh /temp/docker/shared
 RUN ./install.gradle.sh
-ENV GRADLE_HOME "/opt/gradle-3.5"
+ENV GRADLE_HOME "/opt/gradle-8.14.3"
 ENV PATH "$PATH:$GRADLE_HOME/bin"
 
 RUN mkdir -p /temp
@@ -78,9 +81,9 @@ WORKDIR /temp
 RUN cd /temp && gradle --dry-run
 
 # Install the Android tools
-RUN sdkmanager emulator
-RUN sdkmanager tools
-RUN sdkmanager "system-images;android-34;default;arm64-v8a"
+RUN sdkmanager --sdk_root=$ANDROID_HOME emulator
+RUN sdkmanager --sdk_root=$ANDROID_HOME platform-tools
+RUN sdkmanager --sdk_root=$ANDROID_HOME "system-images;android-35;default;arm64-v8a"
 
 # Required for Android ARM Emulator
 RUN apt-get update && apt-get install -y libqt5widgets5

--- a/docker/android/android.arm.toolchain.cmake
+++ b/docker/android/android.arm.toolchain.cmake
@@ -1,9 +1,9 @@
 set(CMAKE_SYSTEM_NAME Android)
-set(CMAKE_SYSTEM_VERSION 34) # API level
+set(CMAKE_SYSTEM_VERSION 35) # API level
 
 set(CMAKE_ANDROID_ARCH arm)
 set(CMAKE_ANDROID_ARCH_ABI armeabi-v7a)
-set(CMAKE_ANDROID_NDK /build/android-ndk-r26b/)
+set(CMAKE_ANDROID_NDK /build/android-ndk-r28c/)
 set(CMAKE_ANDROID_STL_TYPE c++_static)
 
 # ARM specific settings

--- a/docker/android/android.arm64.toolchain.cmake
+++ b/docker/android/android.arm64.toolchain.cmake
@@ -1,8 +1,8 @@
 set(CMAKE_SYSTEM_NAME Android)
-set(CMAKE_SYSTEM_VERSION 34) # API level
+set(CMAKE_SYSTEM_VERSION 35) # API level
 
 set(CMAKE_ANDROID_ARCH arm64)
 set(CMAKE_ANDROID_ARCH_ABI arm64-v8a)
-set(CMAKE_ANDROID_NDK /build/android-ndk-r26b/)
+set(CMAKE_ANDROID_NDK /build/android-ndk-r28c/)
 set(CMAKE_ANDROID_STL_TYPE c++_static)
 

--- a/docker/android/android.x86.toolchain.cmake
+++ b/docker/android/android.x86.toolchain.cmake
@@ -1,7 +1,7 @@
 set(CMAKE_SYSTEM_NAME Android)
-set(CMAKE_SYSTEM_VERSION 34) # API level
+set(CMAKE_SYSTEM_VERSION 35) # API level
 
 set(CMAKE_ANDROID_ARCH x86)
 set(CMAKE_ANDROID_ARCH_ABI x86)
-set(CMAKE_ANDROID_NDK /build/android-ndk-r26b/)
+set(CMAKE_ANDROID_NDK /build/android-ndk-r28c/)
 set(CMAKE_ANDROID_STL_TYPE c++_static)

--- a/docker/android/android.x86_64.toolchain.cmake
+++ b/docker/android/android.x86_64.toolchain.cmake
@@ -1,7 +1,7 @@
 set(CMAKE_SYSTEM_NAME Android)
-set(CMAKE_SYSTEM_VERSION 34) # API level
+set(CMAKE_SYSTEM_VERSION 35) # API level
 
 set(CMAKE_ANDROID_ARCH x86_64)
 set(CMAKE_ANDROID_ARCH_ABI x86_64)
-set(CMAKE_ANDROID_NDK /build/android-ndk-r26b/)
+set(CMAKE_ANDROID_NDK /build/android-ndk-r28c/)
 set(CMAKE_ANDROID_STL_TYPE c++_static)

--- a/docker/android/start-emulator.template.sh
+++ b/docker/android/start-emulator.template.sh
@@ -1,2 +1,2 @@
-echo no | $ANDROID_HOME/tools/android create avd -f -n test -k "system-images;android-34;default;arm64-v8a"
+echo no | $ANDROID_HOME/tools/android create avd -f -n test -k "system-images;android-35;default;arm64-v8a"
 echo no | $ANDROID_HOME/emulator/emulator64$EMU_ARCH -avd test -noaudio -no-window -gpu off -verbose -qemu -usbdevice tablet -vnc :0

--- a/docker/shared/install-android-dependencies.sh
+++ b/docker/shared/install-android-dependencies.sh
@@ -7,11 +7,11 @@
 # Accept licences
 # src http://vgaidarji.me/blog/2017/05/31/automatically-accept-android-sdkmanager-licenses/
 
-for I in "platforms;android-34" \
-         "build-tools;34.0.0"; do
+for I in "platforms;android-35" \
+         "build-tools;35.0.0"; do
     echo "Trying to update with tools/bin/sdkmanager: " $I
-    yes | sdkmanager $I
+    yes | sdkmanager --sdk_root=$ANDROID_HOME $I
 done
 
-sdkmanager --update
-yes | sdkmanager --licenses
+sdkmanager --sdk_root=$ANDROID_HOME  --update
+yes | sdkmanager --sdk_root=$ANDROID_HOME --licenses

--- a/docker/shared/install.gradle.sh
+++ b/docker/shared/install.gradle.sh
@@ -1,5 +1,5 @@
 
 echo "Preparing Gradle..."
 cd /opt/
-curl -L -O https://services.gradle.org/distributions/gradle-3.5-bin.zip
-unzip -qq gradle-3.5-bin.zip
+curl -L -O https://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+unzip -qq gradle-8.14.3-bin.zip

--- a/docker/shared/install.jdk.sh
+++ b/docker/shared/install.jdk.sh
@@ -1,3 +1,3 @@
 apt-get -qq update && \
 	DEBIAN_FRONTEND=noninteractive apt-get -qq install -y \
-	openjdk-8-jdk
+	openjdk-17-jdk

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip

--- a/v8/Dockerfile
+++ b/v8/Dockerfile
@@ -2,6 +2,10 @@ ARG sys_image=ubuntu:20.04
 
 FROM $sys_image
 
+ARG MIRROR=ftp.uni-stuttgart.de/ubuntu
+RUN sed -i "s|archive.ubuntu.com|${MIRROR}|g" /etc/apt/sources.list && \
+    sed -i "s|security.ubuntu.com|${MIRROR}|g" /etc/apt/sources.list
+
 # default values
 ARG vendor=debian
 ARG target_os=linux
@@ -23,7 +27,6 @@ RUN apt-get -qq update && \
     g++ g++-multilib \
     execstack \
     python3 \
-    python \
     python3-pip \
     python3-distutils \
     python3-testresources
@@ -36,18 +39,22 @@ RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
 ENV PATH /v8build/depot_tools:"$PATH"
 RUN echo $PATH
 
+ENV target_os ${target_os}
+
 # Fetch V8 code
-RUN fetch v8
-WORKDIR /v8build/v8
-RUN git checkout 12.0.267.14
-#RUN sed -i 's/snapcraft/nosnapcraft/g' ./build/install-build-deps.sh
-#RUN ./build/install-build-deps.sh
-#RUN sed -i 's/nosnapcraft/snapcraft/g' ./build/install-build-deps.sh
+RUN fetch v8 && \
+    cd /v8build/v8 && \
+    git checkout 12.0.267.14 && \
+    cd /v8build && \
+    echo "target_os= ['${target_os}']" >> .gclient && \
+    gclient sync
+
+
 WORKDIR /v8build
 
-ENV target_os ${target_os}
+
 RUN echo "target_os= ['${target_os}']" >> .gclient
-RUN gclient sync
+RUN gclient sync -D
 
 ENV target_cpu ${target_cpu}
 ENV build_platform ${target_cpu}.release


### PR DESCRIPTION
## General description

This PR contains changes, that are necessary for support of [16kb page size on android](https://developer.android.com/guide/practices/page-sizes)

## Changes list

- Android gradle plugin updated to 8.12.0
- j2v8 is now linked with options `-Wl,-z,max-page-size=16384`
- compileSdk increased to 35
- ndk version updated to 28c
- Android SDK's command line tools version update to `13114758`
- jdk17 is used instead of jdk8 during j2v8 build
- gradle updated to 8.14.3
- Ubuntu archive mirror added to docker files, in order to reduce build time
- Android emulator with api 35 is now used during integration tests