### PR TITLE
Updated V8 to 13.9.205.21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 
 .gradle
 .DS_Store
-*.patch
 *.dll
 *.dylib
 hs_err*.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,7 @@ source_group("" FILES ${src_files})
 #-----------------------------------------------------------------------
 
 # tell gcc/clang to use the c++17 standard
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Android")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-unused-function -Wno-unused-variable -O3 -funroll-loops -ftree-vectorize -ffast-math -fpermissive -fPIC ")
@@ -201,6 +201,7 @@ set(LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/lib)
 include_directories(${include_dirs})
 
 target_link_options(${CMAKE_PROJECT_NAME} PRIVATE "-Wl,-z,max-page-size=16384")
+target_link_options(${CMAKE_PROJECT_NAME} PRIVATE "-Wl,-z,common-page-size=16384")
 
 # link the necessary libraries
 target_link_libraries(j2v8

--- a/docker/android/Dockerfile
+++ b/docker/android/Dockerfile
@@ -83,7 +83,7 @@ RUN cd /temp && gradle --dry-run
 # Install the Android tools
 RUN sdkmanager --sdk_root=$ANDROID_HOME emulator
 RUN sdkmanager --sdk_root=$ANDROID_HOME platform-tools
-RUN sdkmanager --sdk_root=$ANDROID_HOME "system-images;android-35;default;arm64-v8a"
+RUN sdkmanager --sdk_root=$ANDROID_HOME "system-images;android-35;google_apis_ps16k;arm64-v8a"
 
 # Required for Android ARM Emulator
 RUN apt-get update && apt-get install -y libqt5widgets5

--- a/docker/android/start-emulator.template.sh
+++ b/docker/android/start-emulator.template.sh
@@ -1,2 +1,2 @@
-echo no | $ANDROID_HOME/tools/android create avd -f -n test -k "system-images;android-35;default;arm64-v8a"
-echo no | $ANDROID_HOME/emulator/emulator64$EMU_ARCH -avd test -noaudio -no-window -gpu off -verbose -qemu -usbdevice tablet -vnc :0
+echo no | $ANDROID_HOME/tools/android create avd -f -n test -k "system-images;android-35;google_apis_ps16k;arm64-v8a"
+echo no | $ANDROID_HOME/emulator/emulator -avd test -noaudio -no-window -gpu off -verbose -qemu -usbdevice tablet -vnc :0

--- a/v8/Dockerfile
+++ b/v8/Dockerfile
@@ -27,12 +27,14 @@ RUN apt-get -qq update && \
     g++ g++-multilib \
     execstack \
     python3 \
-    python3-pip \
-    python3-distutils \
-    python3-testresources
+    python \
+    python3-distutils \ 
+    python3-testresources \
+    python3-pip
 
 RUN mkdir -p /v8build
 WORKDIR /v8build
+
 
 # DEPOT TOOLS install
 RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
@@ -41,20 +43,20 @@ RUN echo $PATH
 
 ENV target_os ${target_os}
 
-# Fetch V8 code
-RUN fetch v8 && \
-    cd /v8build/v8 && \
-    git checkout 12.0.267.14 && \
-    cd /v8build && \
-    echo "target_os= ['${target_os}']" >> .gclient && \
-    gclient sync
+ENV DEBIAN_FRONTEND=noninteractive
 
+RUN apt-get -qq update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --upgrade -qq -y --no-install-recommends \
+    file keyboard-configuration
 
 WORKDIR /v8build
 
-
-RUN echo "target_os= ['${target_os}']" >> .gclient
-RUN gclient sync -D
+RUN fetch v8 && \
+    cd /v8build/v8 && \
+    git checkout 13.9.205.21 && \
+    cd /v8build && \
+    echo "target_os= ['${target_os}']" >> .gclient && \
+    gclient sync
 
 ENV target_cpu ${target_cpu}
 ENV build_platform ${target_cpu}.release
@@ -64,6 +66,11 @@ WORKDIR /v8build/v8
 RUN apt-get -qq update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --upgrade -qq -y --no-install-recommends \
     pkg-config
+
+COPY patches/ /patches/
+
+RUN cd /v8build/v8 && \
+    git apply /patches/*.patch
 
 RUN ./tools/dev/v8gen.py ${build_platform} -vv
 

--- a/v8/android-arm/args.gn
+++ b/v8/android-arm/args.gn
@@ -10,4 +10,5 @@ v8_enable_i18n_support= false
 symbol_level = 0
 v8_android_log_stdout = true
 v8_enable_pointer_compression = false
-
+v8_static_library = true
+v8_enable_temporal_support = false

--- a/v8/android-arm64/args.gn
+++ b/v8/android-arm64/args.gn
@@ -10,4 +10,5 @@ v8_enable_i18n_support= false
 symbol_level = 0
 v8_android_log_stdout = true
 v8_enable_pointer_compression = false
-
+v8_static_library = true
+v8_enable_temporal_support = false

--- a/v8/android-ia32/args.gn
+++ b/v8/android-ia32/args.gn
@@ -10,3 +10,5 @@ v8_enable_i18n_support= false
 symbol_level = 0
 v8_android_log_stdout = true
 v8_enable_pointer_compression = false
+v8_static_library = true
+v8_enable_temporal_support = false

--- a/v8/android-x64/args.gn
+++ b/v8/android-x64/args.gn
@@ -10,4 +10,5 @@ v8_enable_i18n_support= false
 symbol_level = 0
 v8_android_log_stdout = true
 v8_enable_pointer_compression = false
-
+v8_static_library = true
+v8_enable_temporal_support = false

--- a/v8/patches/builtins-typed-array.cc.patch
+++ b/v8/patches/builtins-typed-array.cc.patch
@@ -1,0 +1,38 @@
+diff --git a/src/builtins/builtins-typed-array.cc b/src/builtins/builtins-typed-array.cc
+index 918cb873481..b2eb2330918 100644
+--- a/src/builtins/builtins-typed-array.cc
++++ b/src/builtins/builtins-typed-array.cc
+@@ -520,17 +520,10 @@ simdutf::result ArrayBufferSetFromBase64(
+     DirectHandle<JSTypedArray> typed_array, size_t& output_length) {
+   output_length = array_length;
+   simdutf::result simd_result;
+-  if (typed_array->buffer()->is_shared()) {
+-    simd_result = simdutf::atomic_base64_to_binary_safe(
+-        reinterpret_cast<const T>(input_vector), input_length,
+-        reinterpret_cast<char*>(typed_array->DataPtr()), output_length,
+-        alphabet, last_chunk_handling, /*decode_up_to_bad_char*/ true);
+-  } else {
+     simd_result = simdutf::base64_to_binary_safe(
+         reinterpret_cast<const T>(input_vector), input_length,
+         reinterpret_cast<char*>(typed_array->DataPtr()), output_length,
+         alphabet, last_chunk_handling, /*decode_up_to_bad_char*/ true);
+-  }
+ 
+   return simd_result;
+ }
+@@ -833,15 +826,9 @@ BUILTIN(Uint8ArrayPrototypeToBase64) {
+     // 11. Return CodePointsToString(outAscii).
+ 
+     size_t simd_result_size;
+-    if (uint8array->buffer()->is_shared()) {
+-      simd_result_size = simdutf::atomic_binary_to_base64(
+-          std::bit_cast<const char*>(uint8array->DataPtr()), length,
+-          reinterpret_cast<char*>(output->GetChars(no_gc)), alphabet);
+-    } else {
+       simd_result_size = simdutf::binary_to_base64(
+           std::bit_cast<const char*>(uint8array->DataPtr()), length,
+           reinterpret_cast<char*>(output->GetChars(no_gc)), alphabet);
+-    }
+     DCHECK_EQ(simd_result_size, output_length);
+     USE(simd_result_size);
+   }

--- a/v8/patches/simd.cc.patch
+++ b/v8/patches/simd.cc.patch
@@ -1,0 +1,52 @@
+diff --git a/src/objects/simd.cc b/src/objects/simd.cc
+index 0ef570ceb7d..898defef310 100644
+--- a/src/objects/simd.cc
++++ b/src/objects/simd.cc
+@@ -477,22 +477,6 @@ void Uint8ArrayToHexSlow(const char* bytes, size_t length,
+   }
+ }
+ 
+-void AtomicUint8ArrayToHexSlow(const char* bytes, size_t length,
+-                               DirectHandle<SeqOneByteString> string_output) {
+-  int index = 0;
+-  // std::atomic_ref<T> must not have a const T, see
+-  // https://cplusplus.github.io/LWG/issue3508
+-  // we instead provide a mutable input, which is ok since we are only reading
+-  // from it.
+-  char* mutable_bytes = const_cast<char*>(bytes);
+-  for (size_t i = 0; i < length; i++) {
+-    uint8_t byte =
+-        std::atomic_ref<char>(mutable_bytes[i]).load(std::memory_order_relaxed);
+-    PerformNibbleToHexAndWriteIntoStringOutPut(byte, index, string_output);
+-    index += 2;
+-  }
+-}
+-
+ inline uint16_t ByteToHex(uint8_t byte) {
+   const uint16_t correction = (('a' - '0' - 10) << 8) + ('a' - '0' - 10);
+ #if V8_TARGET_BIG_ENDIAN
+@@ -645,11 +629,7 @@ Tagged<Object> Uint8ArrayToHex(const char* bytes, size_t length, bool is_shared,
+   }
+ #endif
+ 
+-  if (is_shared) {
+-    AtomicUint8ArrayToHexSlow(bytes, length, string_output);
+-  } else {
+     Uint8ArrayToHexSlow(bytes, length, string_output);
+-  }
+   return *string_output;
+ }
+ 
+@@ -1082,12 +1062,7 @@ bool ArrayBufferFromHex(const base::Vector<T>& input_vector, bool is_shared,
+   for (uint32_t i = 0; i < output_length * 2; i += 2) {
+     result = HandleRemainingHexValues(input_vector, i);
+     if (result.has_value()) {
+-      if (is_shared) {
+-        std::atomic_ref<uint8_t>(buffer[index++])
+-            .store(result.value(), std::memory_order_relaxed);
+-      } else {
+         buffer[index++] = result.value();
+-      }
+     } else {
+       return false;
+     }


### PR DESCRIPTION
## General description

This PR updates V8 version to 13.9.205.21

## Changes list

### V8 build process
- Recent versions of V8 have some issues with build process for android. Looks like these issues are connected with new version of C++ atomic primitives. You can read more about the issue at these links:
   - https://github.com/simdutf/simdutf/issues/827
   - https://github.com/caoccao/Javet/issues/491
   - https://issues.chromium.org/issues/402171653
- In order to solve these issues, source-code patching was added to the V8 build process. The idea behind patching process is quite simple, you just need to avoid usage of new C++ atomic features. Patch files were taken from [Javet project](https://github.com/caoccao/Javet/tree/6fd1c00f2101800447c8ed0391e62e4e53a98e85/scripts/patches/android/v8), which solves these issue with same approach

### JNI Layer
- `SetAccessor` method invocation changed to `SetAccessorProperty` due to the removal of `SetAccessor`  in recent V8 versions
-  Constructor of `ScriptOrigin` now does not require passing `Isolate*`
-  Method `Isolate#IdleNotificationDeadline` was removed in recent V8 versions. This method was used by V8 as a hint about when it is better to run javascript garbage collection. As, it was just a hint, invocations of this method were simply removed in the JNI layer of J2V8. 